### PR TITLE
Bumping up/setting gem versions for mongo and rack

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,8 @@
 source "http://rubygems.org"
 gem 'sinatra'
 gem 'haml'
-gem 'mongo'
+gem 'mongo', '~> 1.12', '>= 1.12.5'
+gem "rack", ">= 1.6.11"
 gem 'json'
 gem 'bson_ext'
 gem 'rsolr'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,56 +1,60 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    bson (1.6.4)
-    bson_ext (1.5.1)
-    builder (3.2.2)
-    faraday (0.9.2)
+    bson (1.12.5)
+    bson_ext (1.12.5)
+      bson (~> 1.12.5)
+    builder (3.2.3)
+    faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
-    faraday_middleware (0.10.1)
+    faraday_middleware (0.12.2)
       faraday (>= 0.7.4, < 1.0)
     gabba (1.0.1)
-    haml (4.0.7)
+    haml (5.0.4)
+      temple (>= 0.8.0)
       tilt
-    hashie (3.4.6)
-    json (2.0.2)
-    jwt (1.5.6)
-    kgio (2.10.0)
-    mini_portile2 (2.1.0)
-    mongo (1.6.4)
-      bson (~> 1.6.4)
+    hashie (3.5.7)
+    json (2.1.0)
+    jwt (2.1.0)
+    kgio (2.11.2)
+    mini_portile2 (2.3.0)
+    mongo (1.12.5)
+      bson (= 1.12.5)
     mono_logger (1.1.0)
-    multi_json (1.12.1)
+    multi_json (1.13.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
-    nokogiri (1.6.8.1)
-      mini_portile2 (~> 2.1.0)
-    oauth2 (1.3.1)
-      faraday (>= 0.8, < 0.12)
-      jwt (~> 1.0)
+    mustermann (1.0.3)
+    nokogiri (1.8.5)
+      mini_portile2 (~> 2.3.0)
+    oauth2 (1.4.1)
+      faraday (>= 0.8, < 0.16.0)
+      jwt (>= 1.0, < 3.0)
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
-    omniauth (1.3.1)
-      hashie (>= 1.2, < 4)
-      rack (>= 1.0, < 3)
-    omniauth-oauth2 (1.4.0)
-      oauth2 (~> 1.0)
+    omniauth (1.8.1)
+      hashie (>= 3.4.6, < 3.6.0)
+      rack (>= 1.6.2, < 3)
+    omniauth-oauth2 (1.5.0)
+      oauth2 (~> 1.1)
       omniauth (~> 1.2)
-    omniauth-orcid (2.0.2)
+    omniauth-orcid (2.1.1)
       omniauth-oauth2 (~> 1.3)
-    parallel (1.10.0)
-    rack (1.6.5)
-    rack-protection (1.5.3)
+      ruby_dig (~> 0.0.2)
+    parallel (1.12.1)
+    rack (2.0.6)
+    rack-protection (2.0.4)
       rack
     rack-session-mongo (0.0.1)
       mongo
       rack
-    raindrops (0.17.0)
-    rake (12.0.0)
-    redis (3.3.2)
-    redis-namespace (1.5.2)
-      redis (~> 3.0, >= 3.0.4)
-    resque (1.26.0)
+    raindrops (0.19.0)
+    rake (12.3.1)
+    redis (4.0.3)
+    redis-namespace (1.6.0)
+      redis (>= 3.0.4)
+    resque (1.27.4)
       mono_logger (~> 1.0)
       multi_json (~> 1.0)
       redis-namespace (~> 1.3)
@@ -59,19 +63,23 @@ GEM
     resque-pool (0.6.0)
       rake
       resque (~> 1.22)
-    rsolr (1.1.2)
+    rsolr (2.2.1)
       builder (>= 2.1.2)
-    sinatra (1.4.7)
-      rack (~> 1.5)
-      rack-protection (~> 1.4)
-      tilt (>= 1.3, < 3)
-    tilt (2.0.5)
-    unicorn (5.2.0)
+      faraday (>= 0.9.0)
+    ruby_dig (0.0.2)
+    sinatra (2.0.4)
+      mustermann (~> 1.0)
+      rack (~> 2.0)
+      rack-protection (= 2.0.4)
+      tilt (~> 2.0)
+    temple (0.8.0)
+    tilt (2.0.9)
+    unicorn (5.4.1)
       kgio (~> 2.6)
       raindrops (~> 0.7)
     vegas (0.1.11)
       rack (>= 1.0.0)
-    will_paginate (3.1.5)
+    will_paginate (3.1.6)
 
 PLATFORMS
   ruby
@@ -84,11 +92,12 @@ DEPENDENCIES
   gabba
   haml
   json
-  mongo
+  mongo (~> 1.12, >= 1.12.5)
   nokogiri
   oauth2
   omniauth-orcid
   parallel
+  rack (>= 1.6.11)
   rack-session-mongo
   rake
   resque
@@ -99,4 +108,4 @@ DEPENDENCIES
   will_paginate
 
 BUNDLED WITH
-   1.13.6
+   1.17.1


### PR DESCRIPTION
Updated and set versioning for mongo and rack. Updated mongo to 1.12.5 which is the last version before version 2. Version 2 breaks backwards compatibility. Rack version updated to reflect security recommendation